### PR TITLE
Add the feature to allow explicit depth for prefix (and fix the wrong ordering) 

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,7 @@ const NAME: &str = "numeq";
 pub struct NumEqPreprocessor {
     /// Whether equation numbers must be prefixed by the section number.
     with_prefix: bool,
+    prefix_depth: usize,
     global: bool,
 }
 
@@ -50,6 +51,10 @@ impl NumEqPreprocessor {
             preprocessor.with_prefix = *b;
         }
 
+        if let Some(toml::Value::Integer(d)) = ctx.config.get("preprocessor.numeq.depth") {
+            preprocessor.prefix_depth = *d as usize;
+        }
+
         if let Some(toml::Value::Boolean(b)) = ctx.config.get("preprocessor.numeq.global") {
             preprocessor.global = *b;
         }
@@ -68,13 +73,18 @@ impl Preprocessor for NumEqPreprocessor {
         let mut refs: HashMap<String, LabelInfo> = HashMap::new();
         // equation counter
         let mut ctr = 0;
+        // store current (sub-)chapter number according to the depth
+        // initialize with one 1 followed by (prefix_depth - 1) zeros
+        let mut ccn: Vec<usize> = vec![1];
+        ccn.resize(self.prefix_depth, 0);
+        warn!("ccn: {:?}", ccn);
         
         for_each_mut_ordered(&mut |item: &mut BookItem| {
         // book.for_each_mut(|item: &mut BookItem| {
             if let BookItem::Chapter(chapter) = item {
                 if !chapter.is_draft_chapter() {
                     // one can safely unwrap chapter.path which must be Some(...)
-                    let prefix = if self.with_prefix {
+                    let mut prefix = if self.with_prefix {
                         match &chapter.number {
                             Some(sn) => sn.to_string(),
                             None => String::new(),
@@ -84,9 +94,35 @@ impl Preprocessor for NumEqPreprocessor {
                     };
                     let path = chapter.path.as_ref().unwrap();
                     // reset counter if global counting is set to false
-                    if !self.global {
+                    if !self.global && self.prefix_depth == 0 {
                         ctr = 0;
                     }
+                    if self.prefix_depth > 0 {
+                        if prefix.is_empty() {
+                            // if prefix is empty, reset counter
+                            ctr = 0;
+                        } else {
+                            // obtain the chapter number as vector of usize
+                            let mut prefix_vec: Vec<usize> = prefix
+                                .trim_end_matches(".").split(".")
+                                .map(|s| s.parse::<usize>().unwrap())
+                                .collect::<Vec<usize>>();
+                            if prefix_vec.len() < self.prefix_depth {
+                                prefix_vec.resize(self.prefix_depth, 0);
+                            }
+                            warn!
+                                ("ccn: {:?}, prefix_vec: {:?}", ccn, prefix_vec);
+                            // if ccn is different from the specifier in prefix_vec, update ccn
+                            if &ccn[..] != &prefix_vec[..self.prefix_depth] {
+                                ccn.copy_from_slice(&prefix_vec[..self.prefix_depth]);
+                                // reset counter
+                                ctr = 0;
+                            }
+                            // update prefix
+                            prefix = ccn.iter().fold(String::new(), |acc, x| acc + &x.to_string() + ".");
+                        }
+                    }
+                    warn!("prefix: {}, path: {:?}", prefix, path);
                     chapter.content =
                         find_and_replace_eqs(&chapter.content, &prefix, path, &mut refs, &mut ctr);
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,7 +77,6 @@ impl Preprocessor for NumEqPreprocessor {
         // initialize with one 1 followed by (prefix_depth - 1) zeros
         let mut ccn: Vec<usize> = vec![1];
         ccn.resize(self.prefix_depth, 0);
-        warn!("ccn: {:?}", ccn);
         
         for_each_mut_ordered(&mut |item: &mut BookItem| {
         // book.for_each_mut(|item: &mut BookItem| {
@@ -110,8 +109,6 @@ impl Preprocessor for NumEqPreprocessor {
                             if prefix_vec.len() < self.prefix_depth {
                                 prefix_vec.resize(self.prefix_depth, 0);
                             }
-                            warn!
-                                ("ccn: {:?}, prefix_vec: {:?}", ccn, prefix_vec);
                             // if ccn is different from the specifier in prefix_vec, update ccn
                             if &ccn[..] != &prefix_vec[..self.prefix_depth] {
                                 ccn.copy_from_slice(&prefix_vec[..self.prefix_depth]);
@@ -122,7 +119,7 @@ impl Preprocessor for NumEqPreprocessor {
                             prefix = ccn.iter().fold(String::new(), |acc, x| acc + &x.to_string() + ".");
                         }
                     }
-                    warn!("prefix: {}, path: {:?}", prefix, path);
+                    
                     chapter.content =
                         find_and_replace_eqs(&chapter.content, &prefix, path, &mut refs, &mut ctr);
                 }


### PR DESCRIPTION
Add the new configuration `depth` which controls how many layers
of prefix should be applied. Setting `depth = 0` will reproduce
the old behaviour. If `depth` is set to numbers strictly greater
than 0, the option `global` will be ignored. Although it should
only make sense to use `depth` of greater than 0 with
`prefix = true`, these two options are independent.

Also, the mdbook function `for_each_mut` orders subchapters before
parent chapters, causing global numbering to be
incorrect. This is fixed by defining and applying the function
`for_each_mut_ordered`, modified from the original `for_each_mut`
function.