### PR TITLE
Fix app name

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,7 @@ use std::io;
 
 /// Parse CLI options.
 pub fn make_app() -> Command {
-    Command::new("mdbook-numthm")
+    Command::new("mdbook-numeq")
         .version(crate_version!())
         .about("An mdbook preprocessor that automatically numbers centered equations")
         .subcommand(


### PR DESCRIPTION
I have just realised that there might be a copy-paste error in the app name.